### PR TITLE
issue #3 fix - last regex match is taken instead of first one

### DIFF
--- a/Source/DynamicPlaceholders/Pipelines/GetChromeData/GetDynamicPlaceholderChromeData.cs
+++ b/Source/DynamicPlaceholders/Pipelines/GetChromeData/GetDynamicPlaceholderChromeData.cs
@@ -24,7 +24,7 @@ namespace DynamicPlaceholders.Pipelines.GetChromeData
 				{
 				    var match = matches.Cast<Match>().Last();
 
-					var newPlaceholderKey = match.Value;
+					var newPlaceholderKey = match.Groups[1].Value;
 
 					args.CustomData["placeHolderKey"] = newPlaceholderKey;
 

--- a/Source/DynamicPlaceholders/Pipelines/GetChromeData/GetDynamicPlaceholderChromeData.cs
+++ b/Source/DynamicPlaceholders/Pipelines/GetChromeData/GetDynamicPlaceholderChromeData.cs
@@ -1,6 +1,7 @@
 ﻿using Sitecore.Diagnostics;
 using Sitecore.Pipelines.GetChromeData;
 using System;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace DynamicPlaceholders.Pipelines.GetChromeData
@@ -16,11 +17,14 @@ namespace DynamicPlaceholders.Pipelines.GetChromeData
 			{
 				var placeholderKey = args.CustomData["placeHolderKey"] as string;
 				var regex = new Regex(DynamicPlaceholders.PlaceholderKeyRegex.DynamicKeyRegex);
-				var match = regex.Match(placeholderKey);
 
-				if (match.Success && match.Groups.Count > 0)
+			    var matches = regex.Matches(placeholderKey);
+
+				if (matches.Count > 0)
 				{
-					var newPlaceholderKey = match.Groups[1].Value;
+				    var match = matches.Cast<Match>().Last();
+
+					var newPlaceholderKey = match.Value;
 
 					args.CustomData["placeHolderKey"] = newPlaceholderKey;
 

--- a/Source/DynamicPlaceholders/Pipelines/GetPlaceholderRenderings/GetDynamicKeyAllowedRenderings.cs
+++ b/Source/DynamicPlaceholders/Pipelines/GetPlaceholderRenderings/GetDynamicKeyAllowedRenderings.cs
@@ -4,6 +4,7 @@ using Sitecore.Data.Items;
 using Sitecore.Diagnostics;
 using Sitecore.Pipelines.GetPlaceholderRenderings;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace DynamicPlaceholders.Pipelines.GetPlaceholderRenderings
@@ -17,11 +18,12 @@ namespace DynamicPlaceholders.Pipelines.GetPlaceholderRenderings
 			var currentPlaceholderKey = args.PlaceholderKey;
 			var temporaryPlaceholderKey = string.Empty;
 			var regex = new Regex(DynamicPlaceholders.PlaceholderKeyRegex.DynamicKeyRegex);
-			var match = regex.Match(currentPlaceholderKey);
+		    var matches = regex.Matches(currentPlaceholderKey);
 
-			if (match.Success && match.Groups.Count > 0)
-			{
-				temporaryPlaceholderKey = match.Groups[1].Value;
+		    if (matches.Count > 0)
+		    {
+		        var match = matches.Cast<Match>().Last();
+                temporaryPlaceholderKey = match.Groups[1].Value;
 			}
 			else
 			{


### PR DESCRIPTION
Hi,

I have run into an issue similar to what is described in [Issue 3](https://github.com/Fortis-Collection/dynamic-placeholders/issues/3):

When nesting a dynamic placeholder inside of another dynamic placeholder, the inner one is rendered in Sitecore Experience Editor with a label and allowed controls of the parent one.

I propose a simple solution to it by taking the last match in regex instead of the first one.